### PR TITLE
Add GitHub Pages config and calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Repository
 
-이 저장소에는 간단한 소개 페이지가 포함되어 있습니다. [index.html](./index.html)을 열어 프로젝트에 대해 더 알아보세요.
+이 저장소에는 GitHub Pages에서 제공할 수 있는 간단한 사칙연산 계산기가 포함되어 있습니다. [index.html](./index.html)을 통해 직접 계산을 해보고, `_config.yml` 파일로 기본 블로그 구성을 확인할 수 있습니다.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: GitHub Calculator
+description: Simple calculator page served with GitHub Pages
+theme: minima

--- a/index.html
+++ b/index.html
@@ -2,10 +2,33 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <title>소개</title>
+  <title>사칙연산 계산기</title>
 </head>
 <body>
-  <h1>프로젝트 소개</h1>
-  <p>이 저장소는 간단한 예시 프로젝트로, Git 사용 방법을 익히기 위한 것입니다.</p>
+  <h1>사칙연산 계산기</h1>
+  <input type="number" id="num1" placeholder="첫 번째 숫자">
+  <select id="operator">
+    <option value="+">+</option>
+    <option value="-">-</option>
+    <option value="*">*</option>
+    <option value="/">/</option>
+  </select>
+  <input type="number" id="num2" placeholder="두 번째 숫자">
+  <button id="calcBtn">계산</button>
+  <p>결과: <span id="result"></span></p>
+
+  <script>
+    document.getElementById('calcBtn').addEventListener('click', function() {
+      const n1 = parseFloat(document.getElementById('num1').value);
+      const n2 = parseFloat(document.getElementById('num2').value);
+      const op = document.getElementById('operator').value;
+      let res;
+      if (op === '+') res = n1 + n2;
+      else if (op === '-') res = n1 - n2;
+      else if (op === '*') res = n1 * n2;
+      else if (op === '/') res = n2 !== 0 ? n1 / n2 : 'NaN';
+      document.getElementById('result').textContent = res;
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- configure site for GitHub Pages
- add a basic arithmetic calculator as the main page
- document the new calculator and configuration

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b923e7508322a502f314c868aeda